### PR TITLE
Refactor logic in LocalRuntime

### DIFF
--- a/openfl-tutorials/experimental/Workflow_Interface_301_MNIST_Watermarking.ipynb
+++ b/openfl-tutorials/experimental/Workflow_Interface_301_MNIST_Watermarking.ipynb
@@ -832,7 +832,7 @@
    "outputs": [],
    "source": [
     "# Inspect Flowgraph\n",
-    "if flflow.checkpoint:\n",
+    "if flflow._checkpoint:\n",
     "    InspectFlow(flflow, flflow._run_id, show_html=True)"
    ]
   },

--- a/openfl/experimental/interface/__init__.py
+++ b/openfl/experimental/interface/__init__.py
@@ -3,7 +3,7 @@
 
 """openfl.experimental.interface package."""
 
-from .fl_spec import FLSpec
+from .fl_spec import FLSpec, final_attributes
 from .participants import Aggregator, Collaborator
 
-__all__ = ["FLSpec", "Aggregator", "Collaborator"]
+__all__ = ["FLSpec", "final_attributes", "Aggregator", "Collaborator"]

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -4,16 +4,15 @@
 """openfl.experimental.interface.flspec module."""
 
 import inspect
-import gc
-from types import MethodType
 from copy import deepcopy
-from openfl.experimental.placement import RayExecutor
 from openfl.experimental.utilities import (
     MetaflowInterface,
     SerializationException,
     aggregator_to_collaborator,
     collaborator_to_aggregator,
     should_transfer,
+    filter_attributes,
+    checkpoint,
 )
 from openfl.experimental.runtime import Runtime
 
@@ -31,17 +30,21 @@ class FLSpec:
 
     @classmethod
     def create_clones(cls, instance, names):
+        """Creates clones for instance for each collaborator in names"""
         cls._clones = {name: deepcopy(instance) for name in names}
 
     @classmethod
     def reset_clones(cls):
+        """Reset clones"""
         cls._clones = []
 
     @classmethod
     def save_initial_state(cls, instance):
+        """Save initial state of instance before executing the flow"""
         cls._initial_state = deepcopy(instance)
 
     def run(self):
+        """Starts the execution of the flow"""
         # Submit flow to Runtime
         self._metaflow_interface = MetaflowInterface(
             self.__class__, self.runtime.backend
@@ -82,40 +85,25 @@ class FLSpec:
             raise Exception("Runtime not supported")
 
     def _setup_aggregator(self):
+        """Sets aggregator private attributes as self attributes"""
         for name, attr in self.runtime._aggregator.private_attributes.items():
             setattr(self, name, attr)
 
     @property
     def runtime(self):
+        """Returns flow runtime"""
         return self._runtime
 
     @runtime.setter
     def runtime(self, runtime):
+        """Sets flow runtime"""
         if isinstance(runtime, Runtime):
             self._runtime = runtime
         else:
             raise TypeError(f"{runtime} is not a valid OpenFL Runtime")
 
-    def parse_attrs(
-        self, exclude=[], reserved_words=["next", "runtime", "input"]
-    ):
-        # TODO Persist attributes to local disk, database, object store, etc. here
-        cls_attrs = []
-        valid_artifacts = []
-        for i in inspect.getmembers(self):
-            if (
-                not hasattr(i[1], "task")
-                and not i[0].startswith("_")
-                and i[0] not in reserved_words
-                and i[0] not in exclude
-                and i not in inspect.getmembers(type(self))
-            ):
-                if not isinstance(i[1], MethodType):
-                    cls_attrs.append(i[0])
-                    valid_artifacts.append((i[0], i[1]))
-        return cls_attrs, valid_artifacts
-
     def capture_instance_snapshot(self, f, parent_func, kwargs):
+        """Takes backup of self before exclude or include filtering"""
         return_objs = []
         if "exclude" in kwargs:
             exclude_backup = deepcopy(self)
@@ -124,86 +112,6 @@ class FLSpec:
             include_backup = deepcopy(self)
             return_objs.append(include_backup)
         return return_objs
-
-    def restore_instance_snapshot(self, instance_snapshot):
-        for backup in instance_snapshot:
-            artifacts_iter, _ = backup.generate_artifacts()
-            for name, attr in artifacts_iter():
-                if not hasattr(self, name):
-                    setattr(self, name, attr)
-
-    def filter_attributes(self, f, **kwargs):
-        """
-        Filter out explicitly included / excluded attributes from the next task
-        in the flow.
-        """
-
-        artifacts_iter, cls_attrs = self.generate_artifacts()
-        if "include" in kwargs and "exclude" in kwargs:
-            raise RuntimeError(
-                "'include' and 'exclude' should not both be present"
-            )
-        elif "include" in kwargs:
-            assert type(kwargs["include"]) == list
-            for in_attr in kwargs["include"]:
-                if in_attr not in cls_attrs:
-                    raise RuntimeError(
-                        f"argument '{in_attr}' not found in flow task {f.__name__}"
-                    )
-            for attr in cls_attrs:
-                if attr not in kwargs["include"]:
-                    delattr(self, attr)
-        elif "exclude" in kwargs:
-            assert type(kwargs["exclude"]) == list
-            for in_attr in kwargs["exclude"]:
-                if in_attr not in cls_attrs:
-                    raise RuntimeError(
-                        f"argument '{in_attr}' not found in flow task {f.__name__}"
-                    )
-            for attr in cls_attrs:
-                if attr in kwargs["exclude"] and hasattr(self, attr):
-                    delattr(self, attr)
-
-    def checkpoint(
-        self, parent_func, chkpnt_reserved_words=["next", "runtime"]
-    ):
-        """
-        [Optionally] save current state for the task just executed task
-        """
-
-        # Extract the stdout & stderr from the buffer
-        # NOTE: Any prints in this method before this line will be recorded as step output/error
-        step_stdout, step_stderr = parent_func._stream_buffer.get_stdstream()
-
-        if self._checkpoint:
-            # all objects will be serialized using Metaflow interface
-            print(f"Saving data artifacts for {parent_func.__name__}")
-            artifacts_iter, _ = self.generate_artifacts(
-                reserved_words=chkpnt_reserved_words
-            )
-            task_id = self._metaflow_interface.create_task(parent_func.__name__)
-            self._metaflow_interface.save_artifacts(
-                artifacts_iter(),
-                task_name=parent_func.__name__,
-                task_id=task_id,
-                buffer_out=step_stdout,
-                buffer_err=step_stderr,
-            )
-            print(f"Saved data artifacts for {parent_func.__name__}")
-
-    def generate_artifacts(self, reserved_words=["next", "runtime", "input"]):
-
-        cls_attrs, valid_artifacts = self.parse_attrs(
-            reserved_words=reserved_words
-        )
-
-        def artifacts_iter():
-            # Helper function from metaflow source
-            while valid_artifacts:
-                var, val = valid_artifacts.pop()
-                yield var, val
-
-        return artifacts_iter, cls_attrs
 
     def is_at_transition_point(self, f, parent_func):
         """
@@ -220,102 +128,15 @@ class FLSpec:
         return False
 
     def display_transition_logs(self, f, parent_func):
+        """
+        Prints aggregator to collaborators or
+        collaborators to aggregator state transition logs
+        """
         if aggregator_to_collaborator(f, parent_func):
             print("Sending state from aggregator to collaborators")
 
         elif collaborator_to_aggregator(f, parent_func):
             print("Sending state from collaborator to aggregator")
-
-    def execute_task(self, f, parent_func, instance_snapshot=(), **kwargs):
-        """
-        Next task execution happens here
-        """
-        global final_attributes
-
-        if "foreach" in kwargs:
-            self._foreach_methods.append(f.__name__)
-            selected_collaborators = self.__getattribute__(kwargs["foreach"])
-
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                if (
-                    "exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
-                ) or (
-                    "include" in kwargs and hasattr(clone, kwargs["include"][0])
-                ):
-                    clone.filter_attributes(f, **kwargs)
-                artifacts_iter, _ = self.generate_artifacts()
-                for name, attr in artifacts_iter():
-                    setattr(clone, name, deepcopy(attr))
-                clone._foreach_methods = self._foreach_methods
-
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                clone.input = col
-                if aggregator_to_collaborator(f, parent_func):
-                    # remove private aggregator state
-                    for attr in self.runtime._aggregator.private_attributes:
-                        self.runtime._aggregator.private_attributes[
-                            attr
-                        ] = getattr(self, attr)
-                        if hasattr(clone, attr):
-                            delattr(clone, attr)
-
-            func = None
-            if self._runtime.backend == "ray":
-                ray_executor = RayExecutor()
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                for name, attr in self.runtime._collaborators[
-                    clone.input
-                ].private_attributes.items():
-                    setattr(clone, name, attr)
-                to_exec = getattr(clone, f.__name__)
-                # write the clone to the object store
-                # ensure clone is getting latest _metaflow_interface
-                clone._metaflow_interface = self._metaflow_interface
-                if self._runtime.backend == "ray":
-                    clone.runtime = Runtime()
-                    ray_executor.ray_call_put(clone, to_exec)
-                else:
-                    to_exec()
-            if self._runtime.backend == "ray":
-                clones = ray_executor.get_remote_clones()
-                FLSpec._clones.update(
-                    {
-                        col: obj
-                        for col, obj in zip(selected_collaborators, clones)
-                    }
-                )
-                del ray_executor
-                del clones
-                gc.collect()
-            for col in selected_collaborators:
-                clone = FLSpec._clones[col]
-                func = clone.execute_next
-                for attr in self.runtime._collaborators[
-                    clone.input
-                ].private_attributes:
-                    if hasattr(clone, attr):
-                        self.runtime._collaborators[
-                            clone.input
-                        ].private_attributes[attr] = getattr(clone, attr)
-                        delattr(clone, attr)
-            # Restore the self state if back-up is taken
-            self.restore_instance_snapshot(instance_snapshot)
-            del instance_snapshot
-
-            g = getattr(self, func)
-            # remove private collaborator state
-            gc.collect()
-            g([FLSpec._clones[col] for col in selected_collaborators])
-        else:
-            to_exec = getattr(self, f.__name__)
-            to_exec()
-            if f.__name__ == "end":
-                self.checkpoint(f)
-                artifacts_iter, _ = self.generate_artifacts()
-                final_attributes = artifacts_iter()
 
     def next(self, f, **kwargs):
         """
@@ -327,7 +148,7 @@ class FLSpec:
         parent_func = getattr(self, parent)
 
         # Checkpoint current attributes (if checkpoint==True)
-        self.checkpoint(parent_func)
+        checkpoint(self, parent_func)
 
         # Take back-up of current state of self
         if aggregator_to_collaborator(f, parent_func):
@@ -336,7 +157,7 @@ class FLSpec:
             )
 
         # Remove included / excluded attributes from next task
-        self.filter_attributes(f, **kwargs)
+        filter_attributes(self, f, **kwargs)
 
         if self.is_at_transition_point(f, parent_func):
             # Collaborator is done executing for now
@@ -346,8 +167,12 @@ class FLSpec:
 
         # if back-up of self is created then pass it to execute_task function
         if "agg_to_collab_ss" in vars():
-            self.execute_task(
-                f, parent_func, instance_snapshot=agg_to_collab_ss, **kwargs
+            self._runtime.execute_task(
+                self,
+                f,
+                parent_func,
+                instance_snapshot=agg_to_collab_ss,
+                **kwargs,
             )
         else:
-            self.execute_task(f, parent_func, **kwargs)
+            self._runtime.execute_task(self, f, parent_func, **kwargs)

--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -16,8 +16,6 @@ from openfl.experimental.utilities import (
     should_transfer,
 )
 from openfl.experimental.runtime import Runtime
-from threading import Lock
-from time import sleep
 
 final_attributes = []
 
@@ -98,7 +96,9 @@ class FLSpec:
         else:
             raise TypeError(f"{runtime} is not a valid OpenFL Runtime")
 
-    def parse_attrs(self, exclude=[], reserved_words=["next", "runtime", "input"]):
+    def parse_attrs(
+        self, exclude=[], reserved_words=["next", "runtime", "input"]
+    ):
         # TODO Persist attributes to local disk, database, object store, etc. here
         cls_attrs = []
         valid_artifacts = []
@@ -140,7 +140,9 @@ class FLSpec:
 
         artifacts_iter, cls_attrs = self.generate_artifacts()
         if "include" in kwargs and "exclude" in kwargs:
-            raise RuntimeError("'include' and 'exclude' should not both be present")
+            raise RuntimeError(
+                "'include' and 'exclude' should not both be present"
+            )
         elif "include" in kwargs:
             assert type(kwargs["include"]) == list
             for in_attr in kwargs["include"]:
@@ -162,7 +164,9 @@ class FLSpec:
                 if attr in kwargs["exclude"] and hasattr(self, attr):
                     delattr(self, attr)
 
-    def checkpoint(self, parent_func, chkpnt_reserved_words=["next", "runtime"]):
+    def checkpoint(
+        self, parent_func, chkpnt_reserved_words=["next", "runtime"]
+    ):
         """
         [Optionally] save current state for the task just executed task
         """
@@ -189,7 +193,9 @@ class FLSpec:
 
     def generate_artifacts(self, reserved_words=["next", "runtime", "input"]):
 
-        cls_attrs, valid_artifacts = self.parse_attrs(reserved_words=reserved_words)
+        cls_attrs, valid_artifacts = self.parse_attrs(
+            reserved_words=reserved_words
+        )
 
         def artifacts_iter():
             # Helper function from metaflow source
@@ -206,7 +212,9 @@ class FLSpec:
         if parent_func.__name__ in self._foreach_methods:
             self._foreach_methods.append(f.__name__)
             if should_transfer(f, parent_func):
-                print(f"Should transfer from {parent_func.__name__} to {f.__name__}")
+                print(
+                    f"Should transfer from {parent_func.__name__} to {f.__name__}"
+                )
                 self.execute_next = f.__name__
                 return True
         return False
@@ -230,7 +238,9 @@ class FLSpec:
 
             for col in selected_collaborators:
                 clone = FLSpec._clones[col]
-                if ("exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])) or (
+                if (
+                    "exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
+                ) or (
                     "include" in kwargs and hasattr(clone, kwargs["include"][0])
                 ):
                     clone.filter_attributes(f, **kwargs)
@@ -245,16 +255,13 @@ class FLSpec:
                 if aggregator_to_collaborator(f, parent_func):
                     # remove private aggregator state
                     for attr in self.runtime._aggregator.private_attributes:
-                        self.runtime._aggregator.private_attributes[attr] = getattr(
-                            self, attr
-                        )
+                        self.runtime._aggregator.private_attributes[
+                            attr
+                        ] = getattr(self, attr)
                         if hasattr(clone, attr):
                             delattr(clone, attr)
 
             func = None
-            func_refs = []
-            remote_functions = []
-            remote_ctx_refs = []
             if self._runtime.backend == "ray":
                 ray_executor = RayExecutor()
             for col in selected_collaborators:
@@ -277,9 +284,7 @@ class FLSpec:
                 FLSpec._clones.update(
                     {
                         col: obj
-                        for col, obj in zip(
-                            selected_collaborators, clones
-                        )
+                        for col, obj in zip(selected_collaborators, clones)
                     }
                 )
                 del ray_executor
@@ -288,11 +293,13 @@ class FLSpec:
             for col in selected_collaborators:
                 clone = FLSpec._clones[col]
                 func = clone.execute_next
-                for attr in self.runtime._collaborators[clone.input].private_attributes:
+                for attr in self.runtime._collaborators[
+                    clone.input
+                ].private_attributes:
                     if hasattr(clone, attr):
-                        self.runtime._collaborators[clone.input].private_attributes[
-                            attr
-                        ] = getattr(clone, attr)
+                        self.runtime._collaborators[
+                            clone.input
+                        ].private_attributes[attr] = getattr(clone, attr)
                         delattr(clone, attr)
             # Restore the self state if back-up is taken
             self.restore_instance_snapshot(instance_snapshot)
@@ -324,7 +331,9 @@ class FLSpec:
 
         # Take back-up of current state of self
         if aggregator_to_collaborator(f, parent_func):
-            agg_to_collab_ss = self.capture_instance_snapshot(f, parent_func, kwargs)
+            agg_to_collab_ss = self.capture_instance_snapshot(
+                f, parent_func, kwargs
+            )
 
         # Remove included / excluded attributes from next task
         self.filter_attributes(f, **kwargs)

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -20,9 +20,7 @@ class RayExecutor:
         remote_to_exec = make_remote(func, num_gpus=func.num_gpus)
         ref_ctx = ray.put(ctx)
         self.remote_contexts.append(ref_ctx)
-        self.remote_functions.append(
-            remote_to_exec.remote(ref_ctx, func.__name__)
-        )
+        self.remote_functions.append(remote_to_exec.remote(ref_ctx, func.__name__))
         del remote_to_exec
         del ref_ctx
 

--- a/openfl/experimental/placement/placement.py
+++ b/openfl/experimental/placement/placement.py
@@ -3,13 +3,13 @@
 
 import functools
 import ray
-import gc
 from copy import deepcopy
 from openfl.experimental.utilities import (
     RedirectStdStreamContext,
     GPUResourcesNotAvailable,
     get_number_of_gpus,
 )
+
 
 class RayExecutor:
     def __init__(self):
@@ -20,7 +20,9 @@ class RayExecutor:
         remote_to_exec = make_remote(func, num_gpus=func.num_gpus)
         ref_ctx = ray.put(ctx)
         self.remote_contexts.append(ref_ctx)
-        self.remote_functions.append(remote_to_exec.remote(ref_ctx, func.__name__))
+        self.remote_functions.append(
+            remote_to_exec.remote(ref_ctx, func.__name__)
+        )
         del remote_to_exec
         del ref_ctx
 

--- a/openfl/experimental/runtime/__init__.py
+++ b/openfl/experimental/runtime/__init__.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""openfl.experimental.runtime package."""
+""" openfl.experimental.runtime package Runtime class."""
 
-from .runtime import LocalRuntime, Runtime
+from .runtime import Runtime
+from .local_runtime import LocalRuntime
+
 
 __all__ = ["LocalRuntime", "Runtime"]

--- a/openfl/experimental/runtime/federated_runtime.py
+++ b/openfl/experimental/runtime/federated_runtime.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+""" openfl.experimental.runtime module FederatedRuntime class."""
+
+from openfl.experimental.runtime import Runtime
+
+
+class FederatedRuntime(Runtime):
+    def __init__(self, aggregator, collaborators=None):
+        """Use remote federated infrastructure to run the flow"""
+        raise NotImplementedError("FederatedRuntime will be implemented in the future")

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -1,0 +1,177 @@
+# Copyright (C) 2020-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+""" openfl.experimental.runtime package LocalRuntime class."""
+
+from copy import deepcopy
+import ray
+import gc
+from openfl.experimental.runtime import Runtime
+from openfl.experimental.placement import RayExecutor
+from openfl.experimental.utilities import (
+    aggregator_to_collaborator,
+    generate_artifacts,
+    filter_attributes,
+    checkpoint,
+)
+
+
+class LocalRuntime(Runtime):
+    def __init__(
+        self,
+        aggregator=None,
+        collaborators=None,
+        backend="single_process",
+        **kwargs,
+    ):
+        """Use Local infrastructure to run the flow"""
+        super().__init__()
+        if backend not in ["ray", "single_process"]:
+            raise ValueError(
+                f"Invalid 'backend' value '{backend}', accepted values are "
+                + "'ray', or 'single_process'"
+            )
+        if backend == "ray":
+            if not ray.is_initialized():
+                dh = kwargs.get("dashboard_host", "127.0.0.1")
+                dp = kwargs.get("dashboard_port", 5252)
+                ray.init(dashboard_host=dh, dashboard_port=dp)
+        self.backend = backend
+        self.aggregator = aggregator
+        # List of envoys should be iterable, so that a subset can be selected at runtime
+        # The envoys is the superset of envoys that can be selected during the experiment
+        if collaborators is not None:
+            self.collaborators = collaborators
+
+    @property
+    def aggregator(self):
+        """Returns name of _aggregator"""
+        return self._aggregator.name
+
+    @aggregator.setter
+    def aggregator(self, aggregator):
+        """Set LocalRuntime _aggregator"""
+        self._aggregator = aggregator
+
+    @property
+    def collaborators(self):
+        """
+        Return names of collaborators. Don't give direct access to private attributes
+        """
+        return list(self._collaborators.keys())
+
+    @collaborators.setter
+    def collaborators(self, collaborators):
+        """Set LocalRuntime collaborators"""
+        self._collaborators = {
+            collaborator.name: collaborator for collaborator in collaborators
+        }
+
+    def restore_instance_snapshot(self, ctx, instance_snapshot):
+        """Restores attributes from backup (in instance snapshot) to ctx"""
+        for backup in instance_snapshot:
+            artifacts_iter, _ = generate_artifacts(ctx=backup)
+            for name, attr in artifacts_iter():
+                if not hasattr(ctx, name):
+                    setattr(ctx, name, attr)
+
+    def execute_task(
+        self, flspec_obj, f, parent_func, instance_snapshot=(), **kwargs
+    ):
+        """
+        Next task execution happens here
+        """
+        from openfl.experimental.interface import (
+            FLSpec,
+            final_attributes,
+        )
+
+        global final_attributes
+
+        if "foreach" in kwargs:
+            flspec_obj._foreach_methods.append(f.__name__)
+            selected_collaborators = flspec_obj.__getattribute__(
+                kwargs["foreach"]
+            )
+
+            for col in selected_collaborators:
+                clone = FLSpec._clones[col]
+                if (
+                    "exclude" in kwargs and hasattr(clone, kwargs["exclude"][0])
+                ) or (
+                    "include" in kwargs and hasattr(clone, kwargs["include"][0])
+                ):
+                    filter_attributes(clone, f, **kwargs)
+                artifacts_iter, _ = generate_artifacts(ctx=flspec_obj)
+                for name, attr in artifacts_iter():
+                    setattr(clone, name, deepcopy(attr))
+                clone._foreach_methods = flspec_obj._foreach_methods
+
+            for col in selected_collaborators:
+                clone = FLSpec._clones[col]
+                clone.input = col
+                if aggregator_to_collaborator(f, parent_func):
+                    # remove private aggregator state
+                    for attr in self._aggregator.private_attributes:
+                        self._aggregator.private_attributes[attr] = getattr(
+                            flspec_obj, attr
+                        )
+                        if hasattr(clone, attr):
+                            delattr(clone, attr)
+
+            func = None
+            if self.backend == "ray":
+                ray_executor = RayExecutor()
+            for col in selected_collaborators:
+                clone = FLSpec._clones[col]
+                for name, attr in self._collaborators[
+                    clone.input
+                ].private_attributes.items():
+                    setattr(clone, name, attr)
+                to_exec = getattr(clone, f.__name__)
+                # write the clone to the object store
+                # ensure clone is getting latest _metaflow_interface
+                clone._metaflow_interface = flspec_obj._metaflow_interface
+                if self.backend == "ray":
+                    clone._runtime = self  # MOD: Runtime()
+                    ray_executor.ray_call_put(clone, to_exec)
+                else:
+                    to_exec()
+            if self.backend == "ray":
+                clones = ray_executor.get_remote_clones()
+                FLSpec._clones.update(
+                    {
+                        col: obj
+                        for col, obj in zip(selected_collaborators, clones)
+                    }
+                )
+                del ray_executor
+                del clones
+                gc.collect()
+            for col in selected_collaborators:
+                clone = FLSpec._clones[col]
+                func = clone.execute_next
+                for attr in self._collaborators[clone.input].private_attributes:
+                    if hasattr(clone, attr):
+                        self._collaborators[clone.input].private_attributes[
+                            attr
+                        ] = getattr(clone, attr)
+                        delattr(clone, attr)
+            # Restore the flspec_obj state if back-up is taken
+            self.restore_instance_snapshot(flspec_obj, instance_snapshot)
+            del instance_snapshot
+
+            g = getattr(flspec_obj, func)
+            # remove private collaborator state
+            gc.collect()
+            g([FLSpec._clones[col] for col in selected_collaborators])
+        else:
+            to_exec = getattr(flspec_obj, f.__name__)
+            to_exec()
+            if f.__name__ == "end":
+                checkpoint(flspec_obj, f)
+                artifacts_iter, _ = generate_artifacts(ctx=flspec_obj)
+                final_attributes = artifacts_iter()
+
+    def __repr__(self):
+        return "LocalRuntime"

--- a/openfl/experimental/runtime/runtime.py
+++ b/openfl/experimental/runtime/runtime.py
@@ -1,9 +1,7 @@
 # Copyright (C) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-""" openfl.experimental.runtime module."""
-
-import ray
+""" openfl.experimental.runtime module Runtime class."""
 
 
 class Runtime:
@@ -13,63 +11,3 @@ class Runtime:
 
         """
         pass
-
-
-class LocalRuntime(Runtime):
-    def __init__(
-        self,
-        aggregator=None,
-        collaborators=None,
-        backend="single_process",
-        **kwargs,
-    ):
-        """Use remote federated infrastructure to run the flow"""
-        super().__init__()
-        if backend not in ["ray", "single_process"]:
-            raise ValueError(
-                f"Invalid 'backend' value '{backend}', accepted values are 'ray', or "
-                + "'single_process'"
-            )
-        if backend == "ray":
-            if not ray.is_initialized():
-                dh = kwargs.get("dashboard_host", "127.0.0.1")
-                dp = kwargs.get("dashboard_port", 5252)
-                ray.init(dashboard_host=dh, dashboard_port=dp)
-        self.backend = backend
-        self.aggregator = aggregator
-        # List of envoys should be iterable, so that a subset can be selected at runtime
-        # The envoys is the superset of envoys that can be selected during the experiment
-        if collaborators is not None:
-            self.collaborators = collaborators
-
-    @property
-    def aggregator(self):
-        return self._aggregator.name
-
-    @aggregator.setter
-    def aggregator(self, aggregator):
-        self._aggregator = aggregator
-
-    @property
-    def collaborators(self):
-        """
-        Return names of collaborators. Don't give direct access to private attributes
-        """
-        return list(self._collaborators.keys())
-
-    @collaborators.setter
-    def collaborators(self, collaborators):
-        self._collaborators = {
-            collaborator.name: collaborator for collaborator in collaborators
-        }
-
-    def __repr__(self):
-        return "LocalRuntime"
-
-
-class FederatedRuntime(Runtime):
-    def __init__(self, aggregator, collaborators=None):
-        """Use remote federated infrastructure to run the flow"""
-        raise NotImplementedError(
-            "FederatedRuntime will be implemented in the future"
-        )

--- a/openfl/experimental/runtime/runtime.py
+++ b/openfl/experimental/runtime/runtime.py
@@ -16,12 +16,19 @@ class Runtime:
 
 
 class LocalRuntime(Runtime):
-    def __init__(self, aggregator=None, collaborators=None, backend="single_process", **kwargs):
+    def __init__(
+        self,
+        aggregator=None,
+        collaborators=None,
+        backend="single_process",
+        **kwargs,
+    ):
         """Use remote federated infrastructure to run the flow"""
         super().__init__()
         if backend not in ["ray", "single_process"]:
             raise ValueError(
-                f"Invalid 'backend' value '{backend}', accepted values are 'ray', or 'single_process'"
+                f"Invalid 'backend' value '{backend}', accepted values are 'ray', or "
+                + "'single_process'"
             )
         if backend == "ray":
             if not ray.is_initialized():
@@ -32,7 +39,7 @@ class LocalRuntime(Runtime):
         self.aggregator = aggregator
         # List of envoys should be iterable, so that a subset can be selected at runtime
         # The envoys is the superset of envoys that can be selected during the experiment
-        if collaborators != None:
+        if collaborators is not None:
             self.collaborators = collaborators
 
     @property
@@ -57,10 +64,12 @@ class LocalRuntime(Runtime):
         }
 
     def __repr__(self):
-        return f"LocalRuntime"
+        return "LocalRuntime"
 
 
 class FederatedRuntime(Runtime):
     def __init__(self, aggregator, collaborators=None):
         """Use remote federated infrastructure to run the flow"""
-        raise NotImplementedError("FederatedRuntime will be implemented in the future")
+        raise NotImplementedError(
+            "FederatedRuntime will be implemented in the future"
+        )

--- a/openfl/experimental/utilities/__init__.py
+++ b/openfl/experimental/utilities/__init__.py
@@ -16,6 +16,13 @@ from .stream_redirect import (
     RedirectStdStreamContext,
 )
 from .resources import get_number_of_gpus
+from .runtime_utils import (
+    parse_attrs,
+    generate_artifacts,
+    filter_attributes,
+    checkpoint,
+)
+
 
 __all__ = [
     "MetaflowInterface",
@@ -28,4 +35,8 @@ __all__ = [
     "RedirectStdStream",
     "RedirectStdStreamContext",
     "get_number_of_gpus",
+    "parse_attrs",
+    "generate_artifacts",
+    "filter_attributes",
+    "checkpoint",
 ]

--- a/openfl/experimental/utilities/runtime_utils.py
+++ b/openfl/experimental/utilities/runtime_utils.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2020-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""openfl.experimental.utilities package."""
+
+import inspect
+from types import MethodType
+
+
+def parse_attrs(ctx, exclude=[], reserved_words=["next", "runtime", "input"]):
+    """Returns ctx attributes and artifacts"""
+    # TODO Persist attributes to local disk, database, object store, etc. here
+    cls_attrs = []
+    valid_artifacts = []
+    for i in inspect.getmembers(ctx):
+        if (
+            not hasattr(i[1], "task")
+            and not i[0].startswith("_")
+            and i[0] not in reserved_words
+            and i[0] not in exclude
+            and i not in inspect.getmembers(type(ctx))
+        ):
+            if not isinstance(i[1], MethodType):
+                cls_attrs.append(i[0])
+                valid_artifacts.append((i[0], i[1]))
+    return cls_attrs, valid_artifacts
+
+
+def generate_artifacts(ctx, reserved_words=["next", "runtime", "input"]):
+    """Returns ctx artifacts, and artifacts_iter method"""
+    cls_attrs, valid_artifacts = parse_attrs(ctx, reserved_words=reserved_words)
+
+    def artifacts_iter():
+        # Helper function from metaflow source
+        while valid_artifacts:
+            var, val = valid_artifacts.pop()
+            yield var, val
+
+    return artifacts_iter, cls_attrs
+
+
+def filter_attributes(ctx, f, **kwargs):
+    """
+    Filter out explicitly included / excluded attributes from the next task
+    in the flow.
+    """
+
+    _, cls_attrs = generate_artifacts(ctx=ctx)
+    if "include" in kwargs and "exclude" in kwargs:
+        raise RuntimeError("'include' and 'exclude' should not both be present")
+    elif "include" in kwargs:
+        assert type(kwargs["include"]) == list
+        for in_attr in kwargs["include"]:
+            if in_attr not in cls_attrs:
+                raise RuntimeError(
+                    f"argument '{in_attr}' not found in flow task {f.__name__}"
+                )
+        for attr in cls_attrs:
+            if attr not in kwargs["include"]:
+                delattr(ctx, attr)
+    elif "exclude" in kwargs:
+        assert type(kwargs["exclude"]) == list
+        for in_attr in kwargs["exclude"]:
+            if in_attr not in cls_attrs:
+                raise RuntimeError(
+                    f"argument '{in_attr}' not found in flow task {f.__name__}"
+                )
+        for attr in cls_attrs:
+            if attr in kwargs["exclude"] and hasattr(ctx, attr):
+                delattr(ctx, attr)
+
+
+def checkpoint(ctx, parent_func, chkpnt_reserved_words=["next", "runtime"]):
+    """
+    [Optionally] save current state for the task just executed task
+    """
+
+    # Extract the stdout & stderr from the buffer
+    # NOTE: Any prints in this method before this line will be recorded as step output/error
+    step_stdout, step_stderr = parent_func._stream_buffer.get_stdstream()
+
+    if ctx._checkpoint:
+        # all objects will be serialized using Metaflow interface
+        print(f"Saving data artifacts for {parent_func.__name__}")
+        artifacts_iter, _ = generate_artifacts(ctx=ctx, reserved_words=chkpnt_reserved_words)
+        task_id = ctx._metaflow_interface.create_task(parent_func.__name__)
+        ctx._metaflow_interface.save_artifacts(
+            artifacts_iter(),
+            task_name=parent_func.__name__,
+            task_id=task_id,
+            buffer_out=step_stdout,
+            buffer_err=step_stderr,
+        )
+        print(f"Saved data artifacts for {parent_func.__name__}")

--- a/openfl/experimental/utilities/utils.py
+++ b/openfl/experimental/utilities/utils.py
@@ -3,5 +3,6 @@
 
 from torch.cuda import device_count
 
+
 def get_number_of_gpus():
     return device_count()


### PR DESCRIPTION
Summary of changes: Refactored LocalRuntime as follows: 
1. Created seperate files for each Runtime (localRuntime & FederatedRuntime)
2. Refactored execute_task method in LocalRuntime from FLSpec
3. Methods used commonly in both functions next, and execute_task are moved to utilities package runtime_utils.py file
4. Updated Watermarking Tutorial to correct the checkpoint usage (flflow.checkpoint to flflow._checkpoint)
5. Resolved flake8 suggestions in openfl/experimental package

Remaining flake8 issues observed are in Global_DP and Privacy_Meter tutorials. Refer [Resolved flake8 suggestions in openfl/experimental package](url)

Verified openfl/tests/github/experimental testcases