### PR TITLE
Bug Fix: aggregator attributes should not be visible in collaborator steps

### DIFF
--- a/openfl/experimental/interface/fl_spec.py
+++ b/openfl/experimental/interface/fl_spec.py
@@ -102,7 +102,7 @@ class FLSpec:
         else:
             raise TypeError(f"{runtime} is not a valid OpenFL Runtime")
 
-    def capture_instance_snapshot(self, f, parent_func, kwargs):
+    def capture_instance_snapshot(self, kwargs):
         """Takes backup of self before exclude or include filtering"""
         return_objs = []
         if "exclude" in kwargs:
@@ -151,10 +151,9 @@ class FLSpec:
         checkpoint(self, parent_func)
 
         # Take back-up of current state of self
+        agg_to_collab_ss = []
         if aggregator_to_collaborator(f, parent_func):
-            agg_to_collab_ss = self.capture_instance_snapshot(
-                f, parent_func, kwargs
-            )
+            agg_to_collab_ss = self.capture_instance_snapshot(kwargs=kwargs)
 
         # Remove included / excluded attributes from next task
         filter_attributes(self, f, **kwargs)
@@ -165,14 +164,10 @@ class FLSpec:
 
         self.display_transition_logs(f, parent_func)
 
-        # if back-up of self is created then pass it to execute_task function
-        if "agg_to_collab_ss" in vars():
-            self._runtime.execute_task(
-                self,
-                f,
-                parent_func,
-                instance_snapshot=agg_to_collab_ss,
-                **kwargs,
-            )
-        else:
-            self._runtime.execute_task(self, f, parent_func, **kwargs)
+        self._runtime.execute_task(
+            self,
+            f,
+            parent_func,
+            instance_snapshot=agg_to_collab_ss,
+            **kwargs,
+        )

--- a/openfl/experimental/runtime/local_runtime.py
+++ b/openfl/experimental/runtime/local_runtime.py
@@ -124,6 +124,11 @@ class LocalRuntime(Runtime):
                 ray_executor = RayExecutor()
             for col in selected_collaborators:
                 clone = FLSpec._clones[col]
+                # Set new LocalRuntime for clone as it is required
+                # for calling execute_task and also new runtime
+                # object will not contain private attributes of
+                # aggregator or other collaborators
+                clone.runtime = LocalRuntime(backend="single_process")
                 for name, attr in self._collaborators[
                     clone.input
                 ].private_attributes.items():
@@ -133,7 +138,6 @@ class LocalRuntime(Runtime):
                 # ensure clone is getting latest _metaflow_interface
                 clone._metaflow_interface = flspec_obj._metaflow_interface
                 if self.backend == "ray":
-                    clone._runtime = self  # MOD: Runtime()
                     ray_executor.ray_call_put(clone, to_exec)
                 else:
                     to_exec()


### PR DESCRIPTION
**Issue Description:** 
While refactoring LocalRuntime an issue was introduced in which Collaborator steps could access private variables of Aggregator via runtime

**Fix Summary**
A new LocalRuntime is created and assigned to clones

**Verification**
Initial results show that the issue is not visible. Need to further test on other test cases