### PR TITLE
[Bug]: Collaborator private attributes were accessible from Aggregator steps

### DIFF
--- a/openfl-tutorials/experimental/Global_DP/Workflow_Interface_Mnist_Implementation_1.py
+++ b/openfl-tutorials/experimental/Global_DP/Workflow_Interface_Mnist_Implementation_1.py
@@ -112,7 +112,10 @@ def FedAvg(models, previous_global_model=None, dp_params=None):
             for key, tensor in state.items():
                 per_layer_norms.append(torch.norm(tensor))
 
-            if torch.norm(torch.Tensor(per_layer_norms)) > dp_params["clip_norm"]:
+            if (
+                torch.norm(torch.Tensor(per_layer_norms))
+                > dp_params["clip_norm"]
+            ):
                 raise ValueError(
                     f"The model with index {idx} had update whose L2-norm was greater than clip norm. Correct the local periodic clipping."
                 )
@@ -302,7 +305,9 @@ class FederatedFlow(FLSpec):
             self.sample_rate = self.dp_params["sample_rate"]
             global_data_loader = DataLoader(
                 self.collaborators,
-                batch_size=int(self.sample_rate * float(len(self.collaborators))),
+                batch_size=int(
+                    self.sample_rate * float(len(self.collaborators))
+                ),
             )
             dp_data_loader = DPDataLoader.from_data_loader(
                 global_data_loader, distributed=False
@@ -330,25 +335,35 @@ class FederatedFlow(FLSpec):
                     exclude=["private"],
                 )
             else:
-                print(f"No collaborator selected for training at Round: {self.round}")
+                print(
+                    f"No collaborator selected for training at Round: {self.round}"
+                )
                 self.next(self.check_round_completion)
         else:
-            print(f"No collaborator selected for training at Round: {self.round}")
+            print(
+                f"No collaborator selected for training at Round: {self.round}"
+            )
             self.next(self.check_round_completion)
 
     # @collaborator                     # Uncomment this if you don't have GPU in the machine and want this application ro run on CPU instead
     @collaborator(num_gpus=1)  # Assuming GPU(s) is available in the machine
     def aggregated_model_validation(self):
-        print(f"Performing aggregated model validation for collaborator {self.input}")
+        print(
+            f"Performing aggregated model validation for collaborator {self.input}"
+        )
         # print(self.device)
         self.model = self.model.to(self.device)
         self.previous_global_model = self.previous_global_model.to(self.device)
 
         # verifying that model went to the correct GPU device
         assert next(self.model.parameters()).device == self.device
-        assert next(self.previous_global_model.parameters()).device == self.device
+        assert (
+            next(self.previous_global_model.parameters()).device == self.device
+        )
 
-        self.agg_validation_score = inference(self.model, self.test_loader, self.device)
+        self.agg_validation_score = inference(
+            self.model, self.test_loader, self.device
+        )
         print(f"{self.input} value of {self.agg_validation_score}")
         self.collaborator_name = self.input
         self.next(self.train)
@@ -384,7 +399,8 @@ class FederatedFlow(FLSpec):
 
             if self.clip_test:
                 optimizer_before_step_params = [
-                    param.data for param in self.optimizer.param_groups()[0]["params"]
+                    param.data
+                    for param in self.optimizer.param_groups()[0]["params"]
                 ]
 
             self.optimizer.step(
@@ -399,7 +415,9 @@ class FederatedFlow(FLSpec):
                     if self.clip_test:
                         optimizer_after_step_params = [
                             param.data
-                            for param in self.optimizer.param_groups()[0]["params"]
+                            for param in self.optimizer.param_groups()[0][
+                                "params"
+                            ]
                         ]
                         clip_testing_on_optimizer_parameters(
                             optimizer_before_step_params,
@@ -423,7 +441,9 @@ class FederatedFlow(FLSpec):
     # @collaborator                     # Uncomment this if you don't have GPU in the machine and want this application ro run on CPU instead
     @collaborator(num_gpus=1)  # Assuming GPU(s) is available in the machine
     def local_model_validation(self):
-        print(f"Performing local model validation for collaborator {self.input}")
+        print(
+            f"Performing local model validation for collaborator {self.input}"
+        )
         # print(self.device)
         self.local_validation_score = inference(
             self.model, self.test_loader, self.device
@@ -444,7 +464,9 @@ class FederatedFlow(FLSpec):
             f"Average aggregated model validation values = {self.aggregated_model_accuracy}"
         )
         print(f"Average training loss = {self.average_loss}")
-        print(f"Average local model validation values = {self.local_model_accuracy}")
+        print(
+            f"Average local model validation values = {self.local_model_accuracy}"
+        )
         if self.dp_params is not None:
             self.model = FedAvg(
                 [input.model.cpu() for input in inputs],
@@ -470,7 +492,9 @@ class FederatedFlow(FLSpec):
                 f"\nCurrent privacy spent using delta={self.dp_params['delta']} is epsilon={epsilon} (best alpha was: {best_alpha})."
             )
             print(20 * "#")
-        self.previous_global_model.load_state_dict(deepcopy(self.model.state_dict()))
+        self.previous_global_model.load_state_dict(
+            deepcopy(self.model.state_dict())
+        )
         self.optimizers.update(
             {input.collaborator_name: input.optimizer for input in inputs}
         )
@@ -492,7 +516,9 @@ class FederatedFlow(FLSpec):
             if self.dp_params is not None:
                 global_data_loader = DataLoader(
                     self.collaborators,
-                    batch_size=int(self.sample_rate * float(len(self.collaborators))),
+                    batch_size=int(
+                        self.sample_rate * float(len(self.collaborators))
+                    ),
                 )
                 dp_data_loader = DPDataLoader.from_data_loader(
                     global_data_loader, distributed=False
@@ -529,7 +555,9 @@ class FederatedFlow(FLSpec):
                     )
                     self.next(self.check_round_completion)
             else:
-                print(f"No collaborator selected for training at Round: {self.round}")
+                print(
+                    f"No collaborator selected for training at Round: {self.round}"
+                )
                 self.next(self.check_round_completion)
 
     @aggregator
@@ -599,8 +627,10 @@ if __name__ == "__main__":
             ),
         }
 
-    local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators)
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    local_runtime = LocalRuntime(
+        aggregator=aggregator, collaborators=collaborators
+    )
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     top_model_accuracy = 0
     model = Net()

--- a/openfl-tutorials/experimental/Global_DP/Workflow_Interface_Mnist_Implementation_2.py
+++ b/openfl-tutorials/experimental/Global_DP/Workflow_Interface_Mnist_Implementation_2.py
@@ -641,7 +641,7 @@ if __name__ == "__main__":
         }
 
     local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators)
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
     best_model = None
     initial_model = Net()
     top_model_accuracy = 0

--- a/openfl-tutorials/experimental/Privacy_Meter/cifar10_PM.py
+++ b/openfl-tutorials/experimental/Privacy_Meter/cifar10_PM.py
@@ -762,7 +762,7 @@ if __name__ == "__main__":
     # local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators, backend='ray')
     local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators)
     
-    print(f'Local runtime collaborators = {local_runtime._collaborators}')
+    print(f'Local runtime collaborators = {local_runtime.collaborators}')
 
     ## change to the internal flow loop
     model = Net()

--- a/openfl-tutorials/experimental/Vertical_FL/Workflow_Interface_VFL_Two_Party.ipynb
+++ b/openfl-tutorials/experimental/Vertical_FL/Workflow_Interface_VFL_Two_Party.ipynb
@@ -165,7 +165,7 @@
     "\n",
     "local_runtime = LocalRuntime(\n",
     "    aggregator=aggregator, collaborators=collaborators, backend='single_process')\n",
-    "print(f'Local runtime collaborators = {local_runtime._collaborators}')\n",
+    "print(f'Local runtime collaborators = {local_runtime.collaborators}')\n",
     "\n",
     "epochs = 100\n",
     "batch_num = 0\n",

--- a/openfl-tutorials/experimental/Vertical_FL/Workflow_Interface_Vertical_FL.ipynb
+++ b/openfl-tutorials/experimental/Vertical_FL/Workflow_Interface_Vertical_FL.ipynb
@@ -130,7 +130,7 @@
     "\n",
     "local_runtime = LocalRuntime(\n",
     "    aggregator=aggregator, collaborators=collaborators)\n",
-    "print(f'Local runtime collaborators = {local_runtime._collaborators}')\n",
+    "print(f'Local runtime collaborators = {local_runtime.collaborators}')\n",
     "\n",
     "vflow = VerticalFlow(checkpoint=True)\n",
     "vflow.runtime = local_runtime\n",

--- a/openfl-tutorials/experimental/Workflow_Interface_101_MNIST.ipynb
+++ b/openfl-tutorials/experimental/Workflow_Interface_101_MNIST.ipynb
@@ -327,7 +327,7 @@
     "    }\n",
     "\n",
     "local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators, backend='single_process')\n",
-    "print(f'Local runtime collaborators = {local_runtime._collaborators}')"
+    "print(f'Local runtime collaborators = {local_runtime.collaborators}')"
    ]
   },
   {

--- a/openfl-tutorials/experimental/Workflow_Interface_102_Aggregator_Validation.ipynb
+++ b/openfl-tutorials/experimental/Workflow_Interface_102_Aggregator_Validation.ipynb
@@ -319,7 +319,7 @@
     "    }\n",
     "\n",
     "local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators, backend='single_process')\n",
-    "print(f'Local runtime collaborators = {local_runtime._collaborators}')"
+    "print(f'Local runtime collaborators = {local_runtime.collaborators}')"
    ]
   },
   {

--- a/openfl-tutorials/experimental/Workflow_Interface_201_Exclusive_GPUs_with_Ray.ipynb
+++ b/openfl-tutorials/experimental/Workflow_Interface_201_Exclusive_GPUs_with_Ray.ipynb
@@ -313,7 +313,7 @@
     "# The following is equivalent to\n",
     "# local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators, **backend='ray'**)\n",
     "local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators)\n",
-    "print(f'Local runtime collaborators = {local_runtime._collaborators}')"
+    "print(f'Local runtime collaborators = {local_runtime.collaborators}')"
    ]
   },
   {
@@ -611,7 +611,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "openfl_github_collab_private",
    "language": "python",
    "name": "python3"
   },
@@ -625,7 +625,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.15 (default, Nov 24 2022, 15:19:38) \n[GCC 11.2.0]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "a9b3ea793f0a9a343a81a73b472831cd604f7c2c0cb7677aa4f9120271015e80"
+   }
   }
  },
  "nbformat": 4,

--- a/openfl-tutorials/experimental/Workflow_Interface_301_MNIST_Watermarking.ipynb
+++ b/openfl-tutorials/experimental/Workflow_Interface_301_MNIST_Watermarking.ipynb
@@ -764,7 +764,7 @@
     "    }\n",
     "\n",
     "local_runtime = LocalRuntime(aggregator=aggregator, collaborators=collaborators)\n",
-    "print(f\"Local runtime collaborators = {local_runtime._collaborators}\")"
+    "print(f\"Local runtime collaborators = {local_runtime.collaborators}\")"
    ]
   },
   {
@@ -854,9 +854,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py3.8",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "py3.8"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -868,11 +868,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.10 (default, Jun 22 2022, 20:18:18) \n[GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "91e603971e1614a722a6cf110d916339d8ca5d12a13bb23038132a65313451b3"
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
    }
   }
  },

--- a/tests/github/experimental/testflow_exclude.py
+++ b/tests/github/experimental/testflow_exclude.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     local_runtime = LocalRuntime(
         aggregator=aggregator, collaborators=collaborators
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     flflow = TestFlowExclude(checkpoint=True)
     flflow.runtime = local_runtime

--- a/tests/github/experimental/testflow_include.py
+++ b/tests/github/experimental/testflow_include.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     local_runtime = LocalRuntime(
         aggregator=aggregator, collaborators=collaborators
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     flflow = TestFlowInclude(checkpoint=True)
     flflow.runtime = local_runtime

--- a/tests/github/experimental/testflow_include_exclude.py
+++ b/tests/github/experimental/testflow_include_exclude.py
@@ -210,7 +210,7 @@ if __name__ == "__main__":
     local_runtime = LocalRuntime(
         aggregator=aggregator, collaborators=collaborators
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
     flflow = TestFlowIncludeExclude(checkpoint=False)
     flflow.runtime = local_runtime
     for i in range(5):

--- a/tests/github/experimental/testflow_internalloop.py
+++ b/tests/github/experimental/testflow_internalloop.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
     local_runtime = LocalRuntime(
         aggregator=aggregator, collaborators=collaborators
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     model = None
     best_model = None

--- a/tests/github/experimental/testflow_privateattributes.py
+++ b/tests/github/experimental/testflow_privateattributes.py
@@ -1,0 +1,239 @@
+# Copyright (C) 2020-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from openfl.experimental.interface import FLSpec, Aggregator, Collaborator
+from openfl.experimental.runtime import LocalRuntime
+from openfl.experimental.placement import aggregator, collaborator
+import numpy as np
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+class TestFlowPrivateAttributes(FLSpec):
+    """
+    Testflow to validate Aggregator private attributes are not accessible to collaborators
+    and vice versa
+    """
+
+    error_list = []
+
+    @aggregator
+    def start(self):
+        """
+        Flow start.
+        """
+        print(
+            f"{bcolors.OKBLUE}Testing FederatedFlow - Starting Test for accessibility of private "
+            + f"attributes  {bcolors.ENDC}"
+        )
+        self.collaborators = self.runtime.collaborators
+
+        validate_collab_private_attr(self, "test_loader", "start")
+
+        self.exclude_agg_to_agg = 10
+        self.include_agg_to_agg = 100
+        self.next(self.aggregator_step, exclude=["exclude_agg_to_agg"])
+
+    @aggregator
+    def aggregator_step(self):
+        """
+        Testing whether Agg private attributes are accessible in next agg step.
+        Collab private attributes should not be accessible here
+        """
+        validate_collab_private_attr(self, "test_loader", "aggregator_step")
+
+        self.include_agg_to_collab = 42
+        self.exclude_agg_to_collab = 40
+        self.next(
+            self.collaborator_step_a,
+            foreach="collaborators",
+            exclude=["exclude_agg_to_collab"],
+        )
+
+    @collaborator
+    def collaborator_step_a(self):
+        """
+        Testing whether Collab private attributes are accessible in collab step
+        Aggregator private attributes should not be accessible here
+        """
+        validate_agg_private_attrs(
+            self, "train_loader", "test_loader", "collaborator_step_a"
+        )
+
+        self.exclude_collab_to_collab = 2
+        self.include_collab_to_collab = 22
+        self.next(
+            self.collaborator_step_b, exclude=["exclude_collab_to_collab"]
+        )
+
+    @collaborator
+    def collaborator_step_b(self):
+        """
+        Testing whether Collab private attributes are accessible in collab step
+        Aggregator private attributes should not be accessible here
+        """
+
+        validate_agg_private_attrs(
+            self, "train_loader", "test_loader", "collaborator_step_b"
+        )
+        self.exclude_collab_to_agg = 10
+        self.include_collab_to_agg = 12
+        self.next(self.join, exclude=["exclude_collab_to_agg"])
+
+    @aggregator
+    def join(self, inputs):
+        """
+        Testing whether attributes are excluded from collab to agg
+        """
+        # Aggregator should only be able to access its own attributes
+        if hasattr(self, "test_loader") is False:
+            TestFlowPrivateAttributes.error_list.append(
+                "aggregator_join_aggregator_attributes_missing"
+            )
+            print(
+                f"{bcolors.FAIL} ... Attribute test failed in join - aggregator private attributes"
+                + f" not accessible {bcolors.ENDC}"
+            )
+
+        for input in enumerate(inputs):
+            if (
+                hasattr(input, "train_loader") is True
+                or hasattr(input, "test_loader") is True
+            ):
+                # Error - we are able to access collaborator attributes
+                TestFlowPrivateAttributes.error_list.append(
+                    "join_collaborator_attributes_found"
+                )
+                print(
+                    f"{bcolors.FAIL} ... Attribute test failed in Join - COllaborator: {collab}"
+                    + f" private attributes accessible {bcolors.ENDC}"
+                )
+
+        self.next(self.end)
+
+    @aggregator
+    def end(self):
+        """
+        This is the 'end' step. All flows must have an 'end' step, which is the
+        last step in the flow.
+
+        """
+        print(
+            f"{bcolors.OKBLUE}Testing FederatedFlow - Ending Test  for accessibility of private "
+            + f"attributes  {bcolors.ENDC}"
+        )
+
+        if TestFlowPrivateAttributes.error_list:
+            raise (
+                AssertionError(
+                    f"{bcolors.FAIL}\n ...Test case failed ... {bcolors.ENDC}"
+                )
+            )
+        else:
+            print(f"{bcolors.OKGREEN}\n ...Test case passed ... {bcolors.ENDC}")
+
+        TestFlowPrivateAttributes.error_list = []
+
+
+def validate_collab_private_attr(self, private_attr, step_name):
+    # Aggregator should only be able to access its own attributes
+    if hasattr(self, private_attr) is False:
+        TestFlowPrivateAttributes.error_list.append(
+            step_name + "_aggregator_attributes_missing"
+        )
+        print(
+            f"{bcolors.FAIL} ...Failed in {step_name} - aggregator private attributes not "
+            + f"accessible {bcolors.ENDC}"
+        )
+
+    for idx, collab in enumerate(self.collaborators):
+        # Collaborator private attributes should not be accessible
+        if (
+            type(self.collaborators[idx]) is not str
+            or hasattr(self.runtime, "_collaborators") is True
+            or hasattr(self.runtime, "__collaborators") is True
+        ):
+            # Error - we are able to access collaborator attributes
+            TestFlowPrivateAttributes.error_list.append(
+                step_name + "_collaborator_attributes_found"
+            )
+            print(
+                f"{bcolors.FAIL} ... Attribute test failed in {step_name} - collaborator {collab} "
+                + f"private attributes accessible {bcolors.ENDC}"
+            )
+
+
+def validate_agg_private_attrs(self, private_attr_1, private_attr_2, step_name):
+    # Collaborator should only be able to access its own attributes
+    if (
+        hasattr(self, private_attr_1) is False
+        or hasattr(self, private_attr_2) is False
+    ):
+        TestFlowPrivateAttributes.error_list.append(
+            step_name + "collab_attributes_not_found"
+        )
+        print(
+            f"{bcolors.FAIL} ... Attribute test failed in {step_name} - Collab "
+            + f"private attributes not accessible {bcolors.ENDC}"
+        )
+
+    if hasattr(self.runtime, "_aggregator") is True:
+        # Error - we are able to access aggregator attributes
+        TestFlowPrivateAttributes.error_list.append(
+            step_name + "_aggregator_attributes_found"
+        )
+        print(
+            f"{bcolors.FAIL} ... Attribute test failed in {step_name} - Aggregator"
+            + f" private attributes accessible {bcolors.ENDC}"
+        )
+
+
+if __name__ == "__main__":
+    # Setup Aggregator with private attributes
+    aggregator = Aggregator()
+    aggregator.private_attributes = {
+        "test_loader": np.random.rand(10, 28, 28)  # Random data
+    }
+
+    # Setup collaborators with private attributes
+    collaborator_names = [
+        "Portland",
+        "Seattle",
+        "Chandler",
+        "Bangalore",
+        "Delhi",
+        "Paris",
+        "New York",
+        "Tel Aviv",
+        "Beijing",
+        "Tokyo",
+    ]
+    collaborators = [Collaborator(name=name) for name in collaborator_names]
+    for idx, collab in enumerate(collaborators):
+        collab.private_attributes = {
+            "train_loader": np.random.rand(idx * 50, 28, 28),
+            "test_loader": np.random.rand(idx * 10, 28, 28),
+        }
+
+    local_runtime = LocalRuntime(
+        aggregator=aggregator, collaborators=collaborators
+    )
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
+
+    flflow = TestFlowPrivateAttributes(checkpoint=False)
+    flflow.runtime = local_runtime
+    for i in range(5):
+        print(f"Starting round {i}...")
+        flflow.run()
+
+    print(f"{bcolors.OKBLUE}End of Testing FederatedFlow {bcolors.ENDC}")

--- a/tests/github/experimental/testflow_reference.py
+++ b/tests/github/experimental/testflow_reference.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
         collaborators=collaborators,
         backend="single_process",
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     testflow = TestFlowReference(checkpoint=True)
     testflow.runtime = local_runtime

--- a/tests/github/experimental/testflow_reference_with_exclude.py
+++ b/tests/github/experimental/testflow_reference_with_exclude.py
@@ -318,7 +318,7 @@ if __name__ == "__main__":
     local_runtime = LocalRuntime(
         aggregator=aggregator, collaborators=collaborators
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     testflow = TestFlow_Reference_With_Exclude(checkpoint=False)
     testflow.runtime = local_runtime

--- a/tests/github/experimental/testflow_reference_with_include.py
+++ b/tests/github/experimental/testflow_reference_with_include.py
@@ -311,7 +311,7 @@ if __name__ == "__main__":
     local_runtime = LocalRuntime(
         aggregator=aggregator, collaborators=collaborators
     )
-    print(f"Local runtime collaborators = {local_runtime._collaborators}")
+    print(f"Local runtime collaborators = {local_runtime.collaborators}")
 
     testflow = TestFlowReferenceWithInclude(checkpoint=False)
     testflow.runtime = local_runtime


### PR DESCRIPTION
**Issue Description**: 
- Collaborator private attributes were accessible from Aggregator steps

**Fix Summary**: 
- Collaborator is now made private attribute of LocalRuntime so that it is not accessible from aggregator steps

**Changes**:

- Framework Modules: collaborator is made a private attribute of LocalRuntime
   openfl/experimental/runtime/local_runtime.py

- New Testcase: Workflow interface test to validate this functionality
  tests/github/experimental/testflow_privateattributes.py

- Updates to existing Test cases: local_runtime._collaborators is modified to local_runtime.collaborator
   tests/github/experimental/testflow_exclude.py
   tests/github/experimental/testflow_include.py
   tests/github/experimental/testflow_include_exclude.py
   tests/github/experimental/testflow_internalloop.py
   tests/github/experimental/testflow_reference.py
   tests/github/experimental/testflow_reference_with_exclude.py
   tests/github/experimental/testflow_reference_with_include.py

- Updates to Tutorials: local_runtime._collaborators is modified to local_runtime.collaborator
   openfl-tutorials/experimental/Global_DP/Workflow_Interface_Mnist_Implementation_1.py
   openfl-tutorials/experimental/Global_DP/Workflow_Interface_Mnist_Implementation_2.py
   openfl-tutorials/experimental/Privacy_Meter/cifar10_PM.py
   openfl-tutorials/experimental/Vertical_FL/Workflow_Interface_VFL_Two_Party.ipynb
   openfl-tutorials/experimental/Vertical_FL/Workflow_Interface_Vertical_FL.ipynb
   openfl-tutorials/experimental/Workflow_Interface_101_MNIST.ipynb
   openfl-tutorials/experimental/Workflow_Interface_102_Aggregator_Validation.ipynb
   openfl-tutorials/experimental/Workflow_Interface_201_Exclusive_GPUs_with_Ray.ipynb
   openfl-tutorials/experimental/Workflow_Interface_301_MNIST_Watermarking.ipynb

